### PR TITLE
Minor bug fix, auto find bin without setting PATH

### DIFF
--- a/src/find-bin.js
+++ b/src/find-bin.js
@@ -1,0 +1,25 @@
+const fs = require("fs")
+const path = require("path")
+
+const binName = process.platform === "win32" ? "tesseract.exe" : "tesseract"
+const pathEnvSep = process.platform === "win32" ? ";" : ":"
+const systemDrive = process.env.SystemDrive
+
+const fallbackPaths = {
+    win32: [
+        `${systemDrive}\\Program Files\\Tesseract-OCR`,
+        `${systemDrive}\\Program Files (x86)\\Tesseract-OCR`,
+    ],
+};
+
+module.exports = function () {
+    const folderPaths = [
+        ...process.env.PATH.split(pathEnvSep),
+        ...(fallbackPaths[process.platform] || [])
+    ]
+
+    for (let i = 0; i < folderPaths.length; i++) {
+        const binPath = path.resolve(folderPaths[i], binName)
+        if (fs.existsSync(binPath)) return binPath
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 const exec = require("child_process").exec
 const log = console.debug
 
+const tesseractBin = require("./find-bin")()
+
 /**
  * @param input - URL, local image path or Buffer
  * @param config - any OCR options and control parameters
@@ -8,7 +10,7 @@ const log = console.debug
  */
 function recognize(input, config = {}) {
   const options = getOptions(config)
-  const binary = config.binary || "tesseract"
+  const binary = `"${config.binary || tesseractBin}"`
   const isSingleLocalFile = typeof input === "string" && !input.match(/^https?:\/\//)
   const inputOption = isSingleLocalFile ? `"${input}"` : "stdin"
   const command = [binary, inputOption, "stdout", ...options].join(" ")


### PR DESCRIPTION
Fixes a bug in binary location - locations with spaces would fail.
Also adds a way to find the bin on Windows by locating through PATH env and pre-determined locations.