### PR TITLE
Fix ERR_CHILD_PROCESS_STDIO_MAXBUFFER

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,14 @@ function recognize(input, config = {}) {
   const isSingleLocalFile = typeof input === "string" && !input.match(/^https?:\/\//)
   const inputOption = isSingleLocalFile ? `"${input}"` : "stdin"
   const command = [binary, inputOption, "stdout", ...options].join(" ")
+  const execOptions = {
+    maxBuffer: 4 * 1024 * 1024
+  }
 
   if (config.debug) log("command", command)
 
   return new Promise((resolve, reject) => {
-    const child = exec(command, (error, stdout, stderr) => {
+    const child = exec(command, execOptions, (error, stdout, stderr) => {
       if (config.debug) log(stderr)
       if (error) reject(error)
       resolve(stdout)


### PR DESCRIPTION
The followin error occurs, when tesseract produces more stderr output than the default nodejs maxBuffer.

`uncaughtException RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stderr maxBuffer length exceeded`

Here I just increase the value by 4x the default and tesseract runs fine again.