### PR TITLE
enhance Return a buffer when producing PDF output via stdout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-tesseract-ocr",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A Node.js wrapper for the Tesseract OCR API",
   "keywords": [
     "ocr",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -192,4 +192,5 @@ export type Config = Partial<{
  * @param config - any OCR options and control parameters
  * @returns default output format is text
  */
+export function recognize(input: Input, config: Config & { presets: (string | Preset)[] & ["pdf"] }): Promise<Buffer>
 export function recognize(input: Input, config?: Config): Promise<string>

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,11 @@ function recognize(input, config = {}) {
   if (config.debug) log("command", command)
 
   return new Promise((resolve, reject) => {
-    const child = exec(command, (error, stdout, stderr) => {
+    const opts = {}
+    if (!config["tessdata-dir"] && config.presets && Array.isArray(config.presets) && config.presets.includes("pdf"))
+      opts.encoding = "buffer"
+
+    const child = exec(command, opts, (error, stdout, stderr) => {
       if (config.debug) log(stderr)
       if (error) reject(error)
       resolve(stdout)

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,10 @@ function recognize(input, config = {}) {
     if (!config["tessdata-dir"] && config.presets && Array.isArray(config.presets) && config.presets.includes("pdf"))
       opts.encoding = "buffer"
 
-    const child = exec(command, opts, (error, stdout, stderr) => {
+    const child = exec(command, {
+      ...opts,
+      maxBuffer: 1024 * 1024 * 32
+    }, (error, stdout, stderr) => {
       if (config.debug) log(stderr)
       if (error) reject(error)
       resolve(stdout)


### PR DESCRIPTION
Currently, there's no way to reliably use the PDF output without writing to disk and then re-reading it.

This PR modifies behaviour to return a Buffer by default if and only if

- The "pdf" preset is present
- No tessdata-dir has been supplied